### PR TITLE
Fix Crunchyroll data fetch: paginate browse endpoint (n≤100)

### DIFF
--- a/scripts/python/update_anime_data.py
+++ b/scripts/python/update_anime_data.py
@@ -276,25 +276,42 @@ def fetch_crunchyroll_anime(access_token: str) -> List[Dict]:
         "Sec-Fetch-Site": "same-origin"
     }
 
-    params = {
-        "n": 2000,  # Fetch up to 2000 items
-        "type": "series",
-        "locale": "en-US",
-        "sort_by": "alphabetical",
-        "ratings": "true",
-        "preferred_audio_language": "ja-JP"
-    }
+    # Crunchyroll caps the page size at 100 per request, so we paginate
+    # using the `start` offset until the full catalog has been retrieved.
+    page_size = 100
 
     all_items = []
+    total = None
 
     try:
-        response = requests.get(url, headers=headers, params=params, timeout=60)
-        response.raise_for_status()
+        start = 0
+        while True:
+            params = {
+                "n": page_size,
+                "start": start,
+                "type": "series",
+                "locale": "en-US",
+                "sort_by": "alphabetical",
+                "ratings": "true",
+                "preferred_audio_language": "ja-JP"
+            }
 
-        data = response.json()
-        items = data.get("data", [])
-        total = data.get("total", 0)
-        all_items.extend(items)
+            response = requests.get(url, headers=headers, params=params, timeout=60)
+            response.raise_for_status()
+
+            data = response.json()
+            items = data.get("data", [])
+            total = data.get("total", 0)
+            all_items.extend(items)
+
+            print(f"  Fetched {len(all_items)} of {total} anime series...")
+
+            # Stop when we've collected everything or the page came back empty
+            if not items or len(all_items) >= total:
+                break
+
+            start += page_size
+            time.sleep(1)  # be gentle to avoid rate limiting / Cloudflare challenges
 
         # Validate format of first item
         if all_items and not validate_crunchyroll_format(all_items[0]):


### PR DESCRIPTION
## Problem

The daily automated data update has been failing every run since **2026-06-10** (last successful update: 2026-06-09, PR #503). The systemd timer and anonymous auth are healthy, but the catalog fetch step fails with:

```
ERROR: Failed to fetch anime: 400 Client Error: Bad Request for url:
.../content/v2/discover/browse?n=2000&type=series&locale=en-US&sort_by=alphabetical&ratings=true&preferred_audio_language=ja-JP
{"error":"Invalid request parameters"}
```

## Root cause

Crunchyroll now **caps the `discover/browse` page size at 100** items per request. The script's single `n=2000` call is rejected (`n=100` works, `n≥101` → 400). This is a Crunchyroll-side change — the script itself hadn't changed since Oct 2025. The `ratings` / `preferred_audio_language` / `sort_by` params are not the issue.

## Fix

Replace the single request in `fetch_crunchyroll_anime` with a paginated loop: `n=100` + `start` offset, iterating until `total` is reached, with a 1s delay between pages to stay under Cloudflare's rate limiting.

## Verification

Ran the fetch live: **1972 / 1972** series retrieved across 20 pages, all IDs unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)