### PR TITLE
Funnel filter counts + Unrated maturity option

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import './App.css'
 import { Anime, FilterState, FilterValue } from './types'
+import { UNRATED_MATURITY } from './utils'
 import {
   Header,
   SearchBar,
@@ -131,6 +132,11 @@ function App() {
     return indexA - indexB
   })
 
+  // Offer an "Unrated" option last if any title lacks a maturity rating
+  if (anime.some(item => !item.series_metadata?.extended_maturity_rating?.rating)) {
+    availableMaturityRatings.push(UNRATED_MATURITY)
+  }
+
   const { filteredAnime, facetCounts } = useMemo(() => {
     const matchesSearch = (item: Anime) =>
       item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -148,17 +154,16 @@ function App() {
       return Boolean(matchesDubbed && matchesSubbed && matchesRating)
     }
 
-    // Maturity rating: each title has a single rating, so included levels use
-    // OR semantics (match any selected level) while excluded levels are removed.
+    // Maturity rating: each title has a single rating (unrated titles use the
+    // UNRATED_MATURITY key), so included levels use OR semantics (match any
+    // selected level) while excluded levels are removed.
     const matchesMaturity = (item: Anime) => {
-      const itemRating = item.series_metadata?.extended_maturity_rating?.rating
+      const itemKey = item.series_metadata?.extended_maturity_rating?.rating ?? UNRATED_MATURITY
       const included = Object.entries(filter.maturityRatings)
         .filter(([, value]) => value === 'include').map(([rating]) => rating)
       const excluded = Object.entries(filter.maturityRatings)
         .filter(([, value]) => value === 'exclude').map(([rating]) => rating)
-      return (included.length === 0 ||
-          (itemRating !== undefined && included.includes(itemRating))) &&
-        (itemRating === undefined || !excluded.includes(itemRating))
+      return (included.length === 0 || included.includes(itemKey)) && !excluded.includes(itemKey)
     }
 
     // Generic tri-state matcher for the multi-value record filters
@@ -209,10 +214,9 @@ function App() {
     // ignoring that section's own selections, so its counts always sum to the
     // funnel total entering the section.
     const counts = {
-      maturityRatingCounts: countValues(afterBasic, item => {
-        const rating = item.series_metadata?.extended_maturity_rating?.rating
-        return rating ? [rating] : []
-      }),
+      maturityRatingCounts: countValues(afterBasic, item => [
+        item.series_metadata?.extended_maturity_rating?.rating ?? UNRATED_MATURITY,
+      ]),
       genreCounts: countValues(afterMaturity, item => item.anilist?.genres || []),
       contentDescriptorCounts: countValues(afterGenres, item => item.series_metadata?.content_descriptors || []),
       tagCounts: countValues(afterContentDescriptors, item => item.anilist?.tags || []),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import './App.css'
-import { Anime, FilterState } from './types'
+import { Anime, FilterState, FilterValue } from './types'
 import {
   Header,
   SearchBar,
@@ -35,7 +35,6 @@ function App() {
 
   const clearFilters = () => {
     setFilter({
-      mature: 'default',
       dubbed: 'default',
       subbed: 'default',
       minRating: 0,
@@ -132,114 +131,124 @@ function App() {
     return indexA - indexB
   })
 
-  const filteredAnime = anime.filter(item => {
-    const matchesSearch = item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         item.description.toLowerCase().includes(searchTerm.toLowerCase())
+  const { filteredAnime, facetCounts } = useMemo(() => {
+    const matchesSearch = (item: Anime) =>
+      item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      item.description.toLowerCase().includes(searchTerm.toLowerCase())
 
-    // Tri-state filter logic: default = any, include = must have, exclude = must not have
-    const matchesDubbed = filter.dubbed === 'default' ||
-                         (filter.dubbed === 'include' && item.series_metadata?.is_dubbed) ||
-                         (filter.dubbed === 'exclude' && !item.series_metadata?.is_dubbed)
-
-    const matchesSubbed = filter.subbed === 'default' ||
-                         (filter.subbed === 'include' && item.series_metadata?.is_subbed) ||
-                         (filter.subbed === 'exclude' && !item.series_metadata?.is_subbed)
-
-    const matchesRating = parseFloat(item.rating?.average || '0') >= filter.minRating
-
-    // Maturity rating filter. Each title has a single rating, so included
-    // levels use OR semantics (match any selected level) while excluded
-    // levels are always removed.
-    const itemMaturityRating = item.series_metadata?.extended_maturity_rating?.rating
-    const includedMaturityRatings = Object.entries(filter.maturityRatings)
-      .filter(([, value]) => value === 'include')
-      .map(([rating]) => rating)
-    const excludedMaturityRatings = Object.entries(filter.maturityRatings)
-      .filter(([, value]) => value === 'exclude')
-      .map(([rating]) => rating)
-    const matchesMaturityRatings =
-      (includedMaturityRatings.length === 0 ||
-        (itemMaturityRating !== undefined && includedMaturityRatings.includes(itemMaturityRating))) &&
-      (itemMaturityRating === undefined || !excludedMaturityRatings.includes(itemMaturityRating))
-
-    // Content descriptor filters
-    const matchesContentDescriptors = Object.entries(filter.contentDescriptors).every(([descriptor, filterValue]) => {
-      if (filterValue === 'default') return true
-      const hasDescriptor = item.series_metadata?.content_descriptors?.includes(descriptor) || false
-      if (filterValue === 'include') return hasDescriptor
-      if (filterValue === 'exclude') return !hasDescriptor
-      return true
-    })
-
-    // Genre filters
-    const matchesGenres = Object.entries(filter.genres).every(([genre, filterValue]) => {
-      if (filterValue === 'default') return true
-      const hasGenre = item.anilist?.genres?.includes(genre) || false
-      if (filterValue === 'include') return hasGenre
-      if (filterValue === 'exclude') return !hasGenre
-      return true
-    })
-
-    // Tag filters
-    const matchesTags = Object.entries(filter.tags).every(([tag, filterValue]) => {
-      if (filterValue === 'default') return true
-      const hasTag = item.anilist?.tags?.includes(tag) || false
-      if (filterValue === 'include') return hasTag
-      if (filterValue === 'exclude') return !hasTag
-      return true
-    })
-
-    // Status filters
-    const matchesStatus = Object.entries(filter.status).every(([status, filterValue]) => {
-      if (filterValue === 'default') return true
-      const hasStatus = item.anilist?.status === status
-      if (filterValue === 'include') return hasStatus
-      if (filterValue === 'exclude') return !hasStatus
-      return true
-    })
-
-    // Studio filters
-    const matchesStudios = Object.entries(filter.studios).every(([studio, filterValue]) => {
-      if (filterValue === 'default') return true
-      const hasStudio = item.anilist?.studios?.includes(studio) || false
-      if (filterValue === 'include') return hasStudio
-      if (filterValue === 'exclude') return !hasStudio
-      return true
-    })
-
-    return matchesSearch && matchesDubbed && matchesSubbed && matchesRating && matchesMaturityRatings && matchesContentDescriptors && matchesGenres && matchesTags && matchesStatus && matchesStudios
-  }).sort((a, b) => {
-    const direction = filter.sortDirection === 'asc' ? 1 : -1
-    
-    let comparison = 0
-    switch (filter.sortBy) {
-      case 'alphabetical':
-        comparison = a.title.localeCompare(b.title)
-        break
-      case 'year':
-        const yearA = a.series_metadata?.series_launch_year || 0
-        const yearB = b.series_metadata?.series_launch_year || 0
-        comparison = yearA - yearB
-        break
-      case 'rating':
-        const ratingA = parseFloat(a.rating?.average || '0')
-        const ratingB = parseFloat(b.rating?.average || '0')
-        comparison = ratingA - ratingB
-        break
-      case 'anilist_rating':
-        const anilistA = a.anilist?.average_score || 0
-        const anilistB = b.anilist?.average_score || 0
-        comparison = anilistA - anilistB
-        break
+    // Basic filters: dubbed/subbed tri-state + minimum star rating
+    const matchesBasic = (item: Anime) => {
+      const matchesDubbed = filter.dubbed === 'default' ||
+        (filter.dubbed === 'include' && item.series_metadata?.is_dubbed) ||
+        (filter.dubbed === 'exclude' && !item.series_metadata?.is_dubbed)
+      const matchesSubbed = filter.subbed === 'default' ||
+        (filter.subbed === 'include' && item.series_metadata?.is_subbed) ||
+        (filter.subbed === 'exclude' && !item.series_metadata?.is_subbed)
+      const matchesRating = parseFloat(item.rating?.average || '0') >= filter.minRating
+      return Boolean(matchesDubbed && matchesSubbed && matchesRating)
     }
 
-    // If values are equal (or for alphabetical), sort by title ascending (always)
-    if (comparison === 0) {
-      return a.title.localeCompare(b.title)
+    // Maturity rating: each title has a single rating, so included levels use
+    // OR semantics (match any selected level) while excluded levels are removed.
+    const matchesMaturity = (item: Anime) => {
+      const itemRating = item.series_metadata?.extended_maturity_rating?.rating
+      const included = Object.entries(filter.maturityRatings)
+        .filter(([, value]) => value === 'include').map(([rating]) => rating)
+      const excluded = Object.entries(filter.maturityRatings)
+        .filter(([, value]) => value === 'exclude').map(([rating]) => rating)
+      return (included.length === 0 ||
+          (itemRating !== undefined && included.includes(itemRating))) &&
+        (itemRating === undefined || !excluded.includes(itemRating))
     }
 
-    return comparison * direction
-  })
+    // Generic tri-state matcher for the multi-value record filters
+    const matchesRecord = (
+      item: Anime,
+      filterObj: Record<string, FilterValue>,
+      has: (item: Anime, key: string) => boolean
+    ) => Object.entries(filterObj).every(([key, value]) => {
+      if (value === 'default') return true
+      return value === 'include' ? has(item, key) : !has(item, key)
+    })
+
+    const matchesGenres = (item: Anime) =>
+      matchesRecord(item, filter.genres, (i, k) => i.anilist?.genres?.includes(k) ?? false)
+    const matchesContentDescriptors = (item: Anime) =>
+      matchesRecord(item, filter.contentDescriptors, (i, k) => i.series_metadata?.content_descriptors?.includes(k) ?? false)
+    const matchesTags = (item: Anime) =>
+      matchesRecord(item, filter.tags, (i, k) => i.anilist?.tags?.includes(k) ?? false)
+    const matchesStatus = (item: Anime) =>
+      matchesRecord(item, filter.status, (i, k) => i.anilist?.status === k)
+    const matchesStudios = (item: Anime) =>
+      matchesRecord(item, filter.studios, (i, k) => i.anilist?.studios?.includes(k) ?? false)
+
+    // Tally how many of `items` carry each value, for the funnel facet counts
+    const countValues = (items: Anime[], getValues: (item: Anime) => string[]) => {
+      const counts: Record<string, number> = {}
+      for (const item of items) {
+        for (const value of getValues(item)) {
+          counts[value] = (counts[value] || 0) + 1
+        }
+      }
+      return counts
+    }
+
+    // Funnel: apply each filter section in the order it appears in the UI, so
+    // each section's option counts reflect the titles that survived every
+    // section above it (search + basic filters first, studios last).
+    const afterSearch = anime.filter(matchesSearch)
+    const afterBasic = afterSearch.filter(matchesBasic)
+    const afterMaturity = afterBasic.filter(matchesMaturity)
+    const afterGenres = afterMaturity.filter(matchesGenres)
+    const afterContentDescriptors = afterGenres.filter(matchesContentDescriptors)
+    const afterTags = afterContentDescriptors.filter(matchesTags)
+    const afterStatus = afterTags.filter(matchesStatus)
+    const afterStudios = afterStatus.filter(matchesStudios)
+
+    // Each facet is counted against its section's input (the set from above),
+    // ignoring that section's own selections, so its counts always sum to the
+    // funnel total entering the section.
+    const counts = {
+      maturityRatingCounts: countValues(afterBasic, item => {
+        const rating = item.series_metadata?.extended_maturity_rating?.rating
+        return rating ? [rating] : []
+      }),
+      genreCounts: countValues(afterMaturity, item => item.anilist?.genres || []),
+      contentDescriptorCounts: countValues(afterGenres, item => item.series_metadata?.content_descriptors || []),
+      tagCounts: countValues(afterContentDescriptors, item => item.anilist?.tags || []),
+      statusCounts: countValues(afterTags, item => (item.anilist?.status ? [item.anilist.status] : [])),
+      studioCounts: countValues(afterStatus, item => item.anilist?.studios || []),
+    }
+
+    const sorted = [...afterStudios].sort((a, b) => {
+      const direction = filter.sortDirection === 'asc' ? 1 : -1
+
+      let comparison = 0
+      switch (filter.sortBy) {
+        case 'alphabetical':
+          comparison = a.title.localeCompare(b.title)
+          break
+        case 'year':
+          comparison = (a.series_metadata?.series_launch_year || 0) - (b.series_metadata?.series_launch_year || 0)
+          break
+        case 'rating':
+          comparison = parseFloat(a.rating?.average || '0') - parseFloat(b.rating?.average || '0')
+          break
+        case 'anilist_rating':
+          comparison = (a.anilist?.average_score || 0) - (b.anilist?.average_score || 0)
+          break
+      }
+
+      // If values are equal (or for alphabetical), sort by title ascending (always)
+      if (comparison === 0) {
+        return a.title.localeCompare(b.title)
+      }
+
+      return comparison * direction
+    })
+
+    return { filteredAnime: sorted, facetCounts: counts }
+  }, [anime, filter, searchTerm])
 
   const totalPages = Math.ceil(filteredAnime.length / itemsPerPage)
   const startIndex = (currentPage - 1) * itemsPerPage
@@ -272,7 +281,12 @@ function App() {
           availableStatuses={availableStatuses}
           availableStudios={availableStudios}
           availableMaturityRatings={availableMaturityRatings}
-          anime={anime}
+          maturityRatingCounts={facetCounts.maturityRatingCounts}
+          genreCounts={facetCounts.genreCounts}
+          contentDescriptorCounts={facetCounts.contentDescriptorCounts}
+          tagCounts={facetCounts.tagCounts}
+          statusCounts={facetCounts.statusCounts}
+          studioCounts={facetCounts.studioCounts}
         />
       </div>
 

--- a/frontend/src/components/FilterControls.tsx
+++ b/frontend/src/components/FilterControls.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react'
-import { FilterState, FilterValue, Anime, SortType, SortDirection } from '../types'
+import { useState } from 'react'
+import { FilterState, FilterValue, SortType, SortDirection } from '../types'
 import { TriStateFilter } from './TriStateFilter'
 import { formatMaturityRating } from '../utils'
 
@@ -15,7 +15,14 @@ interface FilterControlsProps {
   availableStatuses: string[]
   availableStudios: string[]
   availableMaturityRatings: string[]
-  anime: Anime[]
+  // Funnel facet counts: how many titles fit each option given the filters
+  // applied in the sections above it.
+  maturityRatingCounts: Record<string, number>
+  genreCounts: Record<string, number>
+  contentDescriptorCounts: Record<string, number>
+  tagCounts: Record<string, number>
+  statusCounts: Record<string, number>
+  studioCounts: Record<string, number>
 }
 
 export function FilterControls({
@@ -30,7 +37,12 @@ export function FilterControls({
   availableStatuses,
   availableStudios,
   availableMaturityRatings,
-  anime
+  maturityRatingCounts,
+  genreCounts,
+  contentDescriptorCounts,
+  tagCounts,
+  statusCounts,
+  studioCounts
 }: FilterControlsProps) {
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
     basic: true,
@@ -76,31 +88,6 @@ export function FilterControls({
     if (filter.minRating > 0) count++
     return count
   }
-
-  // Calculate count for a specific filter option
-  const getCountForTag = useMemo(() => (tag: string) => {
-    return anime.filter(item => item.anilist?.tags?.includes(tag)).length
-  }, [anime])
-
-  const getCountForGenre = useMemo(() => (genre: string) => {
-    return anime.filter(item => item.anilist?.genres?.includes(genre)).length
-  }, [anime])
-
-  const getCountForStudio = useMemo(() => (studio: string) => {
-    return anime.filter(item => item.anilist?.studios?.includes(studio)).length
-  }, [anime])
-
-  const getCountForStatus = useMemo(() => (status: string) => {
-    return anime.filter(item => item.anilist?.status === status).length
-  }, [anime])
-
-  const getCountForContentDescriptor = useMemo(() => (descriptor: string) => {
-    return anime.filter(item => item.series_metadata?.content_descriptors?.includes(descriptor)).length
-  }, [anime])
-
-  const getCountForMaturityRating = useMemo(() => (rating: string) => {
-    return anime.filter(item => item.series_metadata?.extended_maturity_rating?.rating === rating).length
-  }, [anime])
 
   const handleContentDescriptorChange = (descriptor: string, value: FilterValue) => {
     const newDescriptors = { ...filter.contentDescriptors }
@@ -242,7 +229,7 @@ export function FilterControls({
               {availableMaturityRatings.map(rating => (
                 <TriStateFilter
                   key={rating}
-                  label={`${formatMaturityRating(rating)} (${getCountForMaturityRating(rating)})`}
+                  label={`${formatMaturityRating(rating)} (${maturityRatingCounts[rating] || 0})`}
                   value={filter.maturityRatings[rating] || 'default'}
                   onChange={(value) => handleMaturityRatingChange(rating, value)}
                 />
@@ -281,7 +268,7 @@ export function FilterControls({
               {availableGenres.map(genre => (
                 <TriStateFilter
                   key={genre}
-                  label={`${genre} (${getCountForGenre(genre)})`}
+                  label={`${genre} (${genreCounts[genre] || 0})`}
                   value={filter.genres[genre] || 'default'}
                   onChange={(value) => handleGenreChange(genre, value)}
                 />
@@ -320,7 +307,7 @@ export function FilterControls({
               {availableContentDescriptors.map(descriptor => (
                 <TriStateFilter
                   key={descriptor}
-                  label={`${descriptor} (${getCountForContentDescriptor(descriptor)})`}
+                  label={`${descriptor} (${contentDescriptorCounts[descriptor] || 0})`}
                   value={filter.contentDescriptors[descriptor] || 'default'}
                   onChange={(value) => handleContentDescriptorChange(descriptor, value)}
                 />
@@ -367,7 +354,7 @@ export function FilterControls({
                 {filteredTags.map(tag => (
                   <TriStateFilter
                     key={tag}
-                    label={`${tag} (${getCountForTag(tag)})`}
+                    label={`${tag} (${tagCounts[tag] || 0})`}
                     value={filter.tags[tag] || 'default'}
                     onChange={(value) => handleTagChange(tag, value)}
                   />
@@ -408,7 +395,7 @@ export function FilterControls({
               {availableStatuses.map(status => (
                 <TriStateFilter
                   key={status}
-                  label={`${formatLabel(status)} (${getCountForStatus(status)})`}
+                  label={`${formatLabel(status)} (${statusCounts[status] || 0})`}
                   value={filter.status[status] || 'default'}
                   onChange={(value) => handleStatusChange(status, value)}
                 />
@@ -455,7 +442,7 @@ export function FilterControls({
                 {filteredStudios.map(studio => (
                   <TriStateFilter
                     key={studio}
-                    label={`${studio} (${getCountForStudio(studio)})`}
+                    label={`${studio} (${studioCounts[studio] || 0})`}
                     value={filter.studios[studio] || 'default'}
                     onChange={(value) => handleStudioChange(studio, value)}
                   />

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,6 +1,11 @@
+// Sentinel key for titles that have no maturity rating, so they can be
+// filtered on and counted alongside the real rating values.
+export const UNRATED_MATURITY = '__unrated__'
+
 // Format a Crunchyroll maturity rating (cr-tv system) for display.
 // e.g. 'ALL' -> 'All Ages', '14' -> '14+', 'PG' -> 'PG'
 export function formatMaturityRating(rating: string): string {
+  if (rating === UNRATED_MATURITY) return 'Unrated'
   if (rating === 'ALL') return 'All Ages'
   if (/^\d+$/.test(rating)) return `${rating}+`
   return rating
@@ -9,5 +14,6 @@ export function formatMaturityRating(rating: string): string {
 // A CSS-safe slug for a maturity rating, used for color-coding badges.
 // e.g. 'ALL' -> 'all', '14' -> '14', 'PG' -> 'pg'
 export function maturityRatingSlug(rating: string): string {
+  if (rating === UNRATED_MATURITY) return 'unrated'
   return rating.toLowerCase()
 }


### PR DESCRIPTION
## 1. Funnel filter counts

Filter option counts are now a **funnel**: each section's per-option count reflects the titles that survive every section *above* it, evaluated top-to-bottom — rather than always counting against the full catalog.

Section order: search + basic filters → **Maturity Rating** → **Genres** → **Content Warnings** → **Tags** → **Status** → **Studios**.

A section's counts are computed against its **input set** (titles entering from above) and **ignore that section's own selections**, so they always sum to the funnel total entering it, while the narrowed set flows down.

Example (verified live):

| Stage | results | maturity Σ | 14+ | Action (genre) |
|-------|--------:|-----------:|----:|---------------:|
| baseline | 1963 | 1963 | 966 | 746 |
| + min rating 3★ | 1877 | 1877 | 929 | 727 |
| + include 14+ | 929 | 1877 | 929 | 381 |

## 2. "Unrated" maturity option

Six titles have no maturity rating and were invisible to the maturity filter. Added an **Unrated** option (listed last) via an `UNRATED_MATURITY` sentinel, so those titles can be included/excluded and counted like any other level. Verified: including **Unrated** yields exactly 6 results, and the maturity facet now sums to the full set (1963 at baseline).

## Implementation

- Refactors `App.tsx` filtering into reusable per-dimension predicates; computes the funnel + all facet counts in one `useMemo`, passing count maps to `FilterControls` (which no longer needs the full `anime` list).
- Unrated titles fold into the maturity logic via a sentinel key, which also simplifies the include/exclude predicate.
- Fixes a stray `mature: 'default'` left in `clearFilters` after the Mature-filter removal.

Files: `frontend/src/App.tsx`, `frontend/src/utils.ts`, `frontend/src/components/FilterControls.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)