### PR TITLE
Add audio and subtitle language filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Crunchyroll's metadata is often incomplete. We enhance it with data from AniList
 - **Studio Filters**: Filter by animation studio
 - **Status Filters**: Filter by release status (Releasing, Finished, Not Yet Released)
 - **Content Descriptors**: Filter by content warnings
+- **Audio & Subtitle Language Filters**: Find titles by dub or sub language; selecting several matches titles offering any of them
 - **Basic Filters**: Mature content, dubbed, subbed, minimum rating
 
 ### User Experience

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -272,6 +272,18 @@ header h1 {
   }
 }
 
+.filter-hint {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  color: #888;
+}
+
+@media (prefers-color-scheme: light) {
+  .filter-hint {
+    color: #64748b;
+  }
+}
+
 .content-descriptors {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import './App.css'
 import { Anime, FilterState, FilterValue } from './types'
-import { UNRATED_MATURITY } from './utils'
+import { UNRATED_MATURITY, formatLocale } from './utils'
 import {
   Header,
   SearchBar,
@@ -13,6 +13,22 @@ import {
 // Maturity ratings ordered from least to most restrictive (Crunchyroll cr-tv system)
 const MATURITY_RATING_ORDER = ['ALL', 'PG', '12', '14', '16', '18']
 
+const DEFAULT_FILTER: FilterState = {
+  dubbed: 'default',
+  subbed: 'default',
+  minRating: 0,
+  audioLocales: {},
+  subtitleLocales: {},
+  maturityRatings: {},
+  contentDescriptors: {},
+  genres: {},
+  tags: {},
+  status: {},
+  studios: {},
+  sortBy: 'alphabetical',
+  sortDirection: 'asc'
+}
+
 function App() {
   const [anime, setAnime] = useState<Anime[]>([])
   const [loading, setLoading] = useState<boolean>(true)
@@ -20,34 +36,10 @@ function App() {
   const [currentPage, setCurrentPage] = useState<number>(1)
   const [itemsPerPage, setItemsPerPage] = useState<number>(16)
   const [dataTimestamp, setDataTimestamp] = useState<string>('')
-  const [filter, setFilter] = useState<FilterState>({
-    dubbed: 'default',
-    subbed: 'default',
-    minRating: 0,
-    maturityRatings: {},
-    contentDescriptors: {},
-    genres: {},
-    tags: {},
-    status: {},
-    studios: {},
-    sortBy: 'alphabetical',
-    sortDirection: 'asc'
-  })
+  const [filter, setFilter] = useState<FilterState>(DEFAULT_FILTER)
 
   const clearFilters = () => {
-    setFilter({
-      dubbed: 'default',
-      subbed: 'default',
-      minRating: 0,
-      maturityRatings: {},
-      contentDescriptors: {},
-      genres: {},
-      tags: {},
-      status: {},
-      studios: {},
-      sortBy: 'alphabetical',
-      sortDirection: 'asc'
-    })
+    setFilter(DEFAULT_FILTER)
     setSearchTerm('')
   }
 
@@ -116,6 +108,21 @@ function App() {
     )
   ).sort()
 
+  // Locale codes are sorted by their display name so the option order stays
+  // stable while facet counts shift. Blank codes appear in the data for a
+  // handful of titles and are not offerable options.
+  const collectLocales = (getLocales: (item: Anime) => string[]) =>
+    Array.from(new Set(anime.flatMap(getLocales).filter(Boolean)))
+      .sort((a, b) => formatLocale(a).localeCompare(formatLocale(b)))
+
+  const availableAudioLocales = collectLocales(
+    item => item.series_metadata?.audio_locales || []
+  )
+
+  const availableSubtitleLocales = collectLocales(
+    item => item.series_metadata?.subtitle_locales || []
+  )
+
   const availableMaturityRatings = Array.from(
     new Set(
       anime
@@ -166,6 +173,27 @@ function App() {
       return (included.length === 0 || included.includes(itemKey)) && !excluded.includes(itemKey)
     }
 
+    // Audio/subtitle languages: a title carries a list of locales, so included
+    // languages use OR semantics (match a title offering any selected language)
+    // while a title offering an excluded language is dropped. Membership is
+    // tested per locale code -- the lists themselves are never compared.
+    const matchesLocales = (
+      locales: string[],
+      filterObj: Record<string, FilterValue>
+    ) => {
+      const included = Object.entries(filterObj)
+        .filter(([, value]) => value === 'include').map(([locale]) => locale)
+      const excluded = Object.entries(filterObj)
+        .filter(([, value]) => value === 'exclude').map(([locale]) => locale)
+      return (included.length === 0 || included.some(locale => locales.includes(locale))) &&
+        !excluded.some(locale => locales.includes(locale))
+    }
+
+    const matchesAudioLocales = (item: Anime) =>
+      matchesLocales(item.series_metadata?.audio_locales || [], filter.audioLocales)
+    const matchesSubtitleLocales = (item: Anime) =>
+      matchesLocales(item.series_metadata?.subtitle_locales || [], filter.subtitleLocales)
+
     // Generic tri-state matcher for the multi-value record filters
     const matchesRecord = (
       item: Anime,
@@ -203,7 +231,9 @@ function App() {
     // section above it (search + basic filters first, studios last).
     const afterSearch = anime.filter(matchesSearch)
     const afterBasic = afterSearch.filter(matchesBasic)
-    const afterMaturity = afterBasic.filter(matchesMaturity)
+    const afterAudioLocales = afterBasic.filter(matchesAudioLocales)
+    const afterSubtitleLocales = afterAudioLocales.filter(matchesSubtitleLocales)
+    const afterMaturity = afterSubtitleLocales.filter(matchesMaturity)
     const afterGenres = afterMaturity.filter(matchesGenres)
     const afterContentDescriptors = afterGenres.filter(matchesContentDescriptors)
     const afterTags = afterContentDescriptors.filter(matchesTags)
@@ -214,7 +244,9 @@ function App() {
     // ignoring that section's own selections, so its counts always sum to the
     // funnel total entering the section.
     const counts = {
-      maturityRatingCounts: countValues(afterBasic, item => [
+      audioLocaleCounts: countValues(afterBasic, item => (item.series_metadata?.audio_locales || []).filter(Boolean)),
+      subtitleLocaleCounts: countValues(afterAudioLocales, item => (item.series_metadata?.subtitle_locales || []).filter(Boolean)),
+      maturityRatingCounts: countValues(afterSubtitleLocales, item => [
         item.series_metadata?.extended_maturity_rating?.rating ?? UNRATED_MATURITY,
       ]),
       genreCounts: countValues(afterMaturity, item => item.anilist?.genres || []),
@@ -285,6 +317,10 @@ function App() {
           availableStatuses={availableStatuses}
           availableStudios={availableStudios}
           availableMaturityRatings={availableMaturityRatings}
+          availableAudioLocales={availableAudioLocales}
+          availableSubtitleLocales={availableSubtitleLocales}
+          audioLocaleCounts={facetCounts.audioLocaleCounts}
+          subtitleLocaleCounts={facetCounts.subtitleLocaleCounts}
           maturityRatingCounts={facetCounts.maturityRatingCounts}
           genreCounts={facetCounts.genreCounts}
           contentDescriptorCounts={facetCounts.contentDescriptorCounts}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,10 @@ import {
 // Maturity ratings ordered from least to most restrictive (Crunchyroll cr-tv system)
 const MATURITY_RATING_ORDER = ['ALL', 'PG', '12', '14', '16', '18']
 
-const DEFAULT_FILTER: FilterState = {
+// Built fresh on every call: clearFilters must hand React a new object even
+// when no filter is active, or the state update bails out and the effect that
+// returns the user to page 1 never runs.
+const createDefaultFilter = (): FilterState => ({
   dubbed: 'default',
   subbed: 'default',
   minRating: 0,
@@ -27,7 +30,7 @@ const DEFAULT_FILTER: FilterState = {
   studios: {},
   sortBy: 'alphabetical',
   sortDirection: 'asc'
-}
+})
 
 function App() {
   const [anime, setAnime] = useState<Anime[]>([])
@@ -36,10 +39,10 @@ function App() {
   const [currentPage, setCurrentPage] = useState<number>(1)
   const [itemsPerPage, setItemsPerPage] = useState<number>(16)
   const [dataTimestamp, setDataTimestamp] = useState<string>('')
-  const [filter, setFilter] = useState<FilterState>(DEFAULT_FILTER)
+  const [filter, setFilter] = useState<FilterState>(createDefaultFilter)
 
   const clearFilters = () => {
-    setFilter(DEFAULT_FILTER)
+    setFilter(createDefaultFilter())
     setSearchTerm('')
   }
 

--- a/frontend/src/components/FilterControls.tsx
+++ b/frontend/src/components/FilterControls.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { FilterState, FilterValue, SortType, SortDirection } from '../types'
 import { TriStateFilter } from './TriStateFilter'
-import { formatMaturityRating } from '../utils'
+import { formatLocale, formatMaturityRating } from '../utils'
 
 interface FilterControlsProps {
   filter: FilterState
@@ -15,8 +15,12 @@ interface FilterControlsProps {
   availableStatuses: string[]
   availableStudios: string[]
   availableMaturityRatings: string[]
+  availableAudioLocales: string[]
+  availableSubtitleLocales: string[]
   // Funnel facet counts: how many titles fit each option given the filters
   // applied in the sections above it.
+  audioLocaleCounts: Record<string, number>
+  subtitleLocaleCounts: Record<string, number>
   maturityRatingCounts: Record<string, number>
   genreCounts: Record<string, number>
   contentDescriptorCounts: Record<string, number>
@@ -37,6 +41,10 @@ export function FilterControls({
   availableStatuses,
   availableStudios,
   availableMaturityRatings,
+  availableAudioLocales,
+  availableSubtitleLocales,
+  audioLocaleCounts,
+  subtitleLocaleCounts,
   maturityRatingCounts,
   genreCounts,
   contentDescriptorCounts,
@@ -46,6 +54,8 @@ export function FilterControls({
 }: FilterControlsProps) {
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
     basic: true,
+    audioLocales: false,
+    subtitleLocales: false,
     maturityRatings: false,
     genres: false,
     contentWarnings: false,
@@ -97,6 +107,26 @@ export function FilterControls({
       newDescriptors[descriptor] = value
     }
     onFilterChange({ ...filter, contentDescriptors: newDescriptors })
+  }
+
+  const handleAudioLocaleChange = (locale: string, value: FilterValue) => {
+    const newAudioLocales = { ...filter.audioLocales }
+    if (value === 'default') {
+      delete newAudioLocales[locale]
+    } else {
+      newAudioLocales[locale] = value
+    }
+    onFilterChange({ ...filter, audioLocales: newAudioLocales })
+  }
+
+  const handleSubtitleLocaleChange = (locale: string, value: FilterValue) => {
+    const newSubtitleLocales = { ...filter.subtitleLocales }
+    if (value === 'default') {
+      delete newSubtitleLocales[locale]
+    } else {
+      newSubtitleLocales[locale] = value
+    }
+    onFilterChange({ ...filter, subtitleLocales: newSubtitleLocales })
   }
 
   const handleMaturityRatingChange = (rating: string, value: FilterValue) => {
@@ -199,6 +229,90 @@ export function FilterControls({
           </div>
         )}
       </div>
+      {availableAudioLocales.length > 0 && (
+        <div className="filter-section">
+          <button
+            type="button"
+            className="section-toggle"
+            onClick={() => toggleSection('audioLocales')}
+          >
+            <div className="section-header">
+              <span className="section-label">Audio Language ({availableAudioLocales.length})</span>
+              {(() => {
+                const { included, excluded } = getFilterCounts(filter.audioLocales)
+                if (included > 0 || excluded > 0) {
+                  return (
+                    <span className="filter-count">
+                      {included > 0 && `${included} inc`}
+                      {included > 0 && excluded > 0 && ', '}
+                      {excluded > 0 && `${excluded} exc`}
+                    </span>
+                  )
+                }
+                return null
+              })()}
+            </div>
+            <span className="toggle-icon">{expandedSections.audioLocales ? '▼' : '▶'}</span>
+          </button>
+          {expandedSections.audioLocales && (
+            <>
+              <p className="filter-hint">Matches titles offering any language you include.</p>
+              <div className="content-descriptors">
+                {availableAudioLocales.map(locale => (
+                  <TriStateFilter
+                    key={locale}
+                    label={`${formatLocale(locale)} (${audioLocaleCounts[locale] || 0})`}
+                    value={filter.audioLocales[locale] || 'default'}
+                    onChange={(value) => handleAudioLocaleChange(locale, value)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+      {availableSubtitleLocales.length > 0 && (
+        <div className="filter-section">
+          <button
+            type="button"
+            className="section-toggle"
+            onClick={() => toggleSection('subtitleLocales')}
+          >
+            <div className="section-header">
+              <span className="section-label">Subtitle Language ({availableSubtitleLocales.length})</span>
+              {(() => {
+                const { included, excluded } = getFilterCounts(filter.subtitleLocales)
+                if (included > 0 || excluded > 0) {
+                  return (
+                    <span className="filter-count">
+                      {included > 0 && `${included} inc`}
+                      {included > 0 && excluded > 0 && ', '}
+                      {excluded > 0 && `${excluded} exc`}
+                    </span>
+                  )
+                }
+                return null
+              })()}
+            </div>
+            <span className="toggle-icon">{expandedSections.subtitleLocales ? '▼' : '▶'}</span>
+          </button>
+          {expandedSections.subtitleLocales && (
+            <>
+              <p className="filter-hint">Matches titles offering any language you include.</p>
+              <div className="content-descriptors">
+                {availableSubtitleLocales.map(locale => (
+                  <TriStateFilter
+                    key={locale}
+                    label={`${formatLocale(locale)} (${subtitleLocaleCounts[locale] || 0})`}
+                    value={filter.subtitleLocales[locale] || 'default'}
+                    onChange={(value) => handleSubtitleLocaleChange(locale, value)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
       {availableMaturityRatings.length > 0 && (
         <div className="filter-section">
           <button

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -67,6 +67,8 @@ export interface FilterState {
   dubbed: FilterValue
   subbed: FilterValue
   minRating: number
+  audioLocales: Record<string, FilterValue>
+  subtitleLocales: Record<string, FilterValue>
   maturityRatings: Record<string, FilterValue>
   contentDescriptors: Record<string, FilterValue>
   genres: Record<string, FilterValue>

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -17,3 +17,42 @@ export function maturityRatingSlug(rating: string): string {
   if (rating === UNRATED_MATURITY) return 'unrated'
   return rating.toLowerCase()
 }
+
+// Display names for the audio/subtitle locale codes Crunchyroll uses. Region is
+// kept whenever the same language ships as more than one track (es-419 vs es-ES,
+// pt-BR vs pt-PT), and Chinese entries are named by region rather than script so
+// we don't mislabel a track. Codes missing here fall back to the raw code, so a
+// locale introduced by a future data update still renders — add it below.
+const LANGUAGE_NAMES: Record<string, string> = {
+  'ar-SA': 'Arabic',
+  'ca-ES': 'Catalan',
+  'de-DE': 'German',
+  'en-IN': 'English (India)',
+  'en-US': 'English',
+  'es-419': 'Spanish (Latin America)',
+  'es-ES': 'Spanish (Spain)',
+  'fr-FR': 'French',
+  'hi-IN': 'Hindi',
+  'id-ID': 'Indonesian',
+  'it-IT': 'Italian',
+  'ja-JP': 'Japanese',
+  'ko-KR': 'Korean',
+  'ms-MY': 'Malay',
+  'pl-PL': 'Polish',
+  'pt-BR': 'Portuguese (Brazil)',
+  'pt-PT': 'Portuguese (Portugal)',
+  'ru-RU': 'Russian',
+  'ta-IN': 'Tamil',
+  'te-IN': 'Telugu',
+  'th-TH': 'Thai',
+  'tr-TR': 'Turkish',
+  'vi-VN': 'Vietnamese',
+  'zh-CN': 'Chinese (Simplified)',
+  'zh-HK': 'Chinese (Hong Kong)',
+  'zh-TW': 'Chinese (Taiwan)',
+}
+
+// Format a locale code for display. e.g. 'ja-JP' -> 'Japanese'
+export function formatLocale(code: string): string {
+  return LANGUAGE_NAMES[code] ?? code
+}

--- a/frontend/tests/language-filters.spec.ts
+++ b/frontend/tests/language-filters.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Reads the "N results (Page X of Y)" line above the grid.
+async function resultCount(page: Page): Promise<number> {
+  const text = await page.locator('.results-count').innerText();
+  const match = text.match(/^([\d,]+) results/);
+  if (!match) throw new Error(`Unexpected results count text: ${text}`);
+  return Number(match[1].replace(/,/g, ''));
+}
+
+// Expands a collapsed filter section by its header label.
+async function openSection(page: Page, label: string) {
+  await page.locator('.section-toggle', { hasText: label }).click();
+}
+
+// Clicks a tri-state option the given number of times: once = include,
+// twice = exclude (the button cycles default -> include -> exclude).
+async function cycleOption(page: Page, section: string, option: string, times: number) {
+  const button = page
+    .locator('.filter-section', { has: page.locator('.section-label', { hasText: section }) })
+    .locator('.tri-state-filter', { hasText: option });
+  for (let i = 0; i < times; i++) {
+    await button.click();
+  }
+}
+
+test.describe('Audio and subtitle language filters', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('.anime-grid');
+  });
+
+  test('sections list languages with facet counts', async ({ page }) => {
+    await openSection(page, 'Audio Language');
+
+    const japanese = page
+      .locator('.filter-section', { has: page.locator('.section-label', { hasText: 'Audio Language' }) })
+      .locator('.tri-state-filter', { hasText: 'Japanese' });
+
+    // Label carries a display name and a non-zero count, e.g. "Japanese (1901)"
+    await expect(japanese).toHaveText(/Japanese \([1-9]\d*\)/);
+  });
+
+  test('including a language narrows results', async ({ page }) => {
+    const total = await resultCount(page);
+
+    await openSection(page, 'Audio Language');
+    await cycleOption(page, 'Audio Language', 'German', 1);
+
+    const german = await resultCount(page);
+    expect(german).toBeGreaterThan(0);
+    expect(german).toBeLessThan(total);
+  });
+
+  test('including two languages matches either one (OR), not both', async ({ page }) => {
+    await openSection(page, 'Audio Language');
+
+    await cycleOption(page, 'Audio Language', 'German', 1);
+    const german = await resultCount(page);
+
+    await cycleOption(page, 'Audio Language', 'French', 1);
+    const both = await resultCount(page);
+
+    // OR semantics: adding a second language can only widen the result set.
+    // Under AND semantics this would shrink instead.
+    expect(both).toBeGreaterThan(german);
+  });
+
+  test('excluding a language removes titles offering it', async ({ page }) => {
+    const total = await resultCount(page);
+
+    await openSection(page, 'Subtitle Language');
+    await cycleOption(page, 'Subtitle Language', 'English', 2);
+
+    const withoutEnglish = await resultCount(page);
+    expect(withoutEnglish).toBeGreaterThan(0);
+    expect(withoutEnglish).toBeLessThan(total);
+  });
+
+  test('clear filters resets both language sections', async ({ page }) => {
+    const total = await resultCount(page);
+
+    await openSection(page, 'Audio Language');
+    await cycleOption(page, 'Audio Language', 'German', 1);
+    await openSection(page, 'Subtitle Language');
+    await cycleOption(page, 'Subtitle Language', 'Italian', 1);
+    expect(await resultCount(page)).toBeLessThan(total);
+
+    await page.locator('.clear-filters-btn').click();
+    expect(await resultCount(page)).toBe(total);
+  });
+});

--- a/frontend/tests/language-filters.spec.ts
+++ b/frontend/tests/language-filters.spec.ts
@@ -19,12 +19,17 @@ async function openSection(page: Page, label: string) {
   await section(page, label).locator('.section-toggle').click();
 }
 
-// A single language option, matched on the start of its label so that
-// "English" never picks up "English (India)".
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// A single language option, matched on its whole label -- "Name (count)" -- so
+// that "English" cannot also pick up "English (India)".
 function option(page: Page, sectionLabel: string, language: string): Locator {
+  const label = new RegExp(`^${escapeRegExp(language)} \\(\\d+\\)$`);
   return section(page, sectionLabel)
     .locator('.tri-state-filter')
-    .filter({ has: page.locator('.tri-state-label', { hasText: new RegExp(`^${language} \\(`) }) });
+    .filter({ has: page.locator('.tri-state-label', { hasText: label }) });
 }
 
 // The facet count rendered in an option's label, e.g. "German (215)" -> 215.
@@ -68,10 +73,11 @@ test.describe('Audio and subtitle language filters', () => {
     const labels = await section(page, 'Audio Language').locator('.tri-state-label').allInnerTexts();
 
     expect(labels.length).toBeGreaterThan(0);
-    // A raw code leaking through means the locale is missing from
-    // LANGUAGE_NAMES in src/utils.ts -- add it there.
+    // Display names are capitalised and locale codes are not, which catches any
+    // length of subtag ('ja-JP', 'fil-PH'). A lowercase name means the locale is
+    // missing from LANGUAGE_NAMES in src/utils.ts -- add it there.
     for (const label of labels) {
-      expect(label).not.toMatch(/^[a-z]{2}-[A-Z0-9]+\s/);
+      expect(label.replace(/\s*\(\d+\)$/, '')).toMatch(/^[A-Z]/);
     }
   });
 
@@ -188,6 +194,18 @@ test.describe('Audio and subtitle language filters', () => {
     await openSection(page, 'Audio Language');
     await cycle(page, 'Audio Language', 'Japanese', INCLUDE);
     expect(await resultCount(page)).toBeLessThanOrEqual(searchOnly);
+  });
+
+  test('clear filters returns to the first page even with nothing selected', async ({ page }) => {
+    for (let i = 0; i < 3; i++) {
+      await page.locator('.pagination button', { hasText: 'Next' }).click();
+    }
+    await expect(page.locator('.results-count')).not.toContainText('Page 1 of');
+
+    // Regression guard: clearFilters must hand React a fresh filter object, or
+    // the update bails out and the page-reset effect never runs.
+    await page.locator('.clear-filters-btn').click();
+    await expect(page.locator('.results-count')).toContainText('Page 1 of');
   });
 
   test('clear filters resets both language sections', async ({ page }) => {

--- a/frontend/tests/language-filters.spec.ts
+++ b/frontend/tests/language-filters.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page, Locator } from '@playwright/test';
 
 // Reads the "N results (Page X of Y)" line above the grid.
 async function resultCount(page: Page): Promise<number> {
@@ -8,21 +8,44 @@ async function resultCount(page: Page): Promise<number> {
   return Number(match[1].replace(/,/g, ''));
 }
 
-// Expands a collapsed filter section by its header label.
-async function openSection(page: Page, label: string) {
-  await page.locator('.section-toggle', { hasText: label }).click();
+function section(page: Page, label: string): Locator {
+  return page.locator('.filter-section', {
+    has: page.locator('.section-label', { hasText: label }),
+  });
 }
 
-// Clicks a tri-state option the given number of times: once = include,
-// twice = exclude (the button cycles default -> include -> exclude).
-async function cycleOption(page: Page, section: string, option: string, times: number) {
-  const button = page
-    .locator('.filter-section', { has: page.locator('.section-label', { hasText: section }) })
-    .locator('.tri-state-filter', { hasText: option });
+// Expands a collapsed filter section by its header label.
+async function openSection(page: Page, label: string) {
+  await section(page, label).locator('.section-toggle').click();
+}
+
+// A single language option, matched on the start of its label so that
+// "English" never picks up "English (India)".
+function option(page: Page, sectionLabel: string, language: string): Locator {
+  return section(page, sectionLabel)
+    .locator('.tri-state-filter')
+    .filter({ has: page.locator('.tri-state-label', { hasText: new RegExp(`^${language} \\(`) }) });
+}
+
+// The facet count rendered in an option's label, e.g. "German (215)" -> 215.
+async function optionCount(page: Page, sectionLabel: string, language: string): Promise<number> {
+  const text = await option(page, sectionLabel, language).locator('.tri-state-label').innerText();
+  const match = text.match(/\((\d+)\)$/);
+  if (!match) throw new Error(`Unexpected option label: ${text}`);
+  return Number(match[1]);
+}
+
+// The button cycles default -> include -> exclude -> default.
+async function cycle(page: Page, sectionLabel: string, language: string, times: number) {
+  const button = option(page, sectionLabel, language);
   for (let i = 0; i < times; i++) {
     await button.click();
   }
 }
+
+const INCLUDE = 1;
+const EXCLUDE = 2;
+const RESET = 3;
 
 test.describe('Audio and subtitle language filters', () => {
   test.beforeEach(async ({ page }) => {
@@ -32,22 +55,43 @@ test.describe('Audio and subtitle language filters', () => {
 
   test('sections list languages with facet counts', async ({ page }) => {
     await openSection(page, 'Audio Language');
+    await expect(option(page, 'Audio Language', 'Japanese').locator('.tri-state-label'))
+      .toHaveText(/^Japanese \([1-9]\d*\)$/);
 
-    const japanese = page
-      .locator('.filter-section', { has: page.locator('.section-label', { hasText: 'Audio Language' }) })
-      .locator('.tri-state-filter', { hasText: 'Japanese' });
-
-    // Label carries a display name and a non-zero count, e.g. "Japanese (1901)"
-    await expect(japanese).toHaveText(/Japanese \([1-9]\d*\)/);
+    await openSection(page, 'Subtitle Language');
+    await expect(option(page, 'Subtitle Language', 'English').locator('.tri-state-label'))
+      .toHaveText(/^English \([1-9]\d*\)$/);
   });
 
-  test('including a language narrows results', async ({ page }) => {
+  test('options render display names, not raw locale codes', async ({ page }) => {
+    await openSection(page, 'Audio Language');
+    const labels = await section(page, 'Audio Language').locator('.tri-state-label').allInnerTexts();
+
+    expect(labels.length).toBeGreaterThan(0);
+    // A raw code leaking through means the locale is missing from
+    // LANGUAGE_NAMES in src/utils.ts -- add it there.
+    for (const label of labels) {
+      expect(label).not.toMatch(/^[a-z]{2}-[A-Z0-9]+\s/);
+    }
+  });
+
+  test('options are ordered by display name', async ({ page }) => {
+    await openSection(page, 'Subtitle Language');
+    const labels = await section(page, 'Subtitle Language').locator('.tri-state-label').allInnerTexts();
+    const names = labels.map(label => label.replace(/\s*\(\d+\)$/, ''));
+
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  test('including a language narrows results to its facet count', async ({ page }) => {
     const total = await resultCount(page);
 
     await openSection(page, 'Audio Language');
-    await cycleOption(page, 'Audio Language', 'German', 1);
+    const german = await optionCount(page, 'Audio Language', 'German');
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
 
-    const german = await resultCount(page);
+    // The facet count promises exactly what the filter delivers.
+    expect(await resultCount(page)).toBe(german);
     expect(german).toBeGreaterThan(0);
     expect(german).toBeLessThan(total);
   });
@@ -55,38 +99,110 @@ test.describe('Audio and subtitle language filters', () => {
   test('including two languages matches either one (OR), not both', async ({ page }) => {
     await openSection(page, 'Audio Language');
 
-    await cycleOption(page, 'Audio Language', 'German', 1);
-    const german = await resultCount(page);
+    const germanOnly = await optionCount(page, 'Audio Language', 'German');
+    const frenchOnly = await optionCount(page, 'Audio Language', 'French');
 
-    await cycleOption(page, 'Audio Language', 'French', 1);
-    const both = await resultCount(page);
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
+    await cycle(page, 'Audio Language', 'French', INCLUDE);
+    const either = await resultCount(page);
 
-    // OR semantics: adding a second language can only widen the result set.
-    // Under AND semantics this would shrink instead.
-    expect(both).toBeGreaterThan(german);
+    // OR: the union is at least as large as either language alone, and no
+    // larger than their sum. Under AND semantics this would be smaller.
+    expect(either).toBeGreaterThan(germanOnly);
+    expect(either).toBeGreaterThan(frenchOnly);
+    expect(either).toBeLessThanOrEqual(germanOnly + frenchOnly);
   });
 
   test('excluding a language removes titles offering it', async ({ page }) => {
     const total = await resultCount(page);
 
     await openSection(page, 'Subtitle Language');
-    await cycleOption(page, 'Subtitle Language', 'English', 2);
+    const english = await optionCount(page, 'Subtitle Language', 'English');
+    await cycle(page, 'Subtitle Language', 'English', EXCLUDE);
 
-    const withoutEnglish = await resultCount(page);
-    expect(withoutEnglish).toBeGreaterThan(0);
-    expect(withoutEnglish).toBeLessThan(total);
+    expect(await resultCount(page)).toBe(total - english);
+  });
+
+  test('excluding beats including when a title offers both languages', async ({ page }) => {
+    await openSection(page, 'Audio Language');
+
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
+    const german = await resultCount(page);
+
+    // Nearly every dub also ships the original Japanese track, so excluding it
+    // must drop those titles even though German is included.
+    await cycle(page, 'Audio Language', 'Japanese', EXCLUDE);
+    expect(await resultCount(page)).toBeLessThan(german);
+  });
+
+  test('a third click clears an option again', async ({ page }) => {
+    const total = await resultCount(page);
+
+    await openSection(page, 'Audio Language');
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
+    expect(await resultCount(page)).toBeLessThan(total);
+
+    await cycle(page, 'Audio Language', 'German', RESET - INCLUDE);
+    expect(await resultCount(page)).toBe(total);
+  });
+
+  test('audio and subtitle sections narrow each other', async ({ page }) => {
+    await openSection(page, 'Audio Language');
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
+    const germanDub = await resultCount(page);
+
+    await openSection(page, 'Subtitle Language');
+    await cycle(page, 'Subtitle Language', 'Italian', INCLUDE);
+
+    // Separate sections still AND together, as every other section pair does.
+    expect(await resultCount(page)).toBeLessThanOrEqual(germanDub);
+  });
+
+  test('facet counts funnel from the sections above', async ({ page }) => {
+    await openSection(page, 'Subtitle Language');
+    const italianBefore = await optionCount(page, 'Subtitle Language', 'Italian');
+
+    await openSection(page, 'Audio Language');
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
+    const germanDub = await resultCount(page);
+
+    // Subtitle counts now describe only the German-dubbed titles above them.
+    const italianAfter = await optionCount(page, 'Subtitle Language', 'Italian');
+    expect(italianAfter).toBeLessThan(italianBefore);
+    expect(italianAfter).toBeLessThanOrEqual(germanDub);
+  });
+
+  test('section header reports included and excluded counts', async ({ page }) => {
+    await openSection(page, 'Audio Language');
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
+    await cycle(page, 'Audio Language', 'French', EXCLUDE);
+
+    await expect(section(page, 'Audio Language').locator('.filter-count')).toHaveText('1 inc, 1 exc');
+  });
+
+  test('language filters compose with the search box', async ({ page }) => {
+    await page.locator('.search-input').fill('dragon');
+    const searchOnly = await resultCount(page);
+    expect(searchOnly).toBeGreaterThan(0);
+
+    await openSection(page, 'Audio Language');
+    await cycle(page, 'Audio Language', 'Japanese', INCLUDE);
+    expect(await resultCount(page)).toBeLessThanOrEqual(searchOnly);
   });
 
   test('clear filters resets both language sections', async ({ page }) => {
     const total = await resultCount(page);
 
     await openSection(page, 'Audio Language');
-    await cycleOption(page, 'Audio Language', 'German', 1);
+    await cycle(page, 'Audio Language', 'German', INCLUDE);
     await openSection(page, 'Subtitle Language');
-    await cycleOption(page, 'Subtitle Language', 'Italian', 1);
+    await cycle(page, 'Subtitle Language', 'Italian', INCLUDE);
     expect(await resultCount(page)).toBeLessThan(total);
 
     await page.locator('.clear-filters-btn').click();
+
     expect(await resultCount(page)).toBe(total);
+    await expect(section(page, 'Audio Language').locator('.filter-count')).toHaveCount(0);
+    await expect(section(page, 'Subtitle Language').locator('.filter-count')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Closes #531.

Adds two tri-state filter sections — **Audio Language** (22 options) and **Subtitle Language** (24) — placed directly after Basic Filters, since they refine the Dubbed/Subbed toggles that live there.

No data pipeline work was needed: `audio_locales` and `subtitle_locales` were already present on every title in `anime.json` and already typed in `types.ts`; nothing read them.

## Filter semantics

Included languages use **OR** semantics — a title matches if it offers *any* selected language — following the maturity-rating section rather than the AND-of-includes used by genres, tags, and studios. Excluding a language drops any title offering it, and exclude wins over include when a title has both.

The array fields make this the only workable semantics. AND-of-includes cannot express "one of these languages", and excluding the complement is not equivalent:

| Query | True OR | Exclude the other locales |
|---|---|---|
| German **or** French dub | 251 titles | **0 titles** |
| German **or** Italian subs | 1,267 titles | 176 titles, none of them matching |

Every German or French dub also ships `ja-JP` (1,901 of 1,993 titles carry it), so excluding the complement removes exactly the titles you were asking for. Membership is therefore tested per locale code — the locale arrays are never compared as a unit.

Because the two new sections behave differently from the ones below them, each carries a one-line hint: "Matches titles offering any language you include."

## Changes

- `types.ts` — `audioLocales` / `subtitleLocales` added to `FilterState`
- `utils.ts` — `formatLocale` with a display-name map covering all 26 locale codes in the catalog, falling back to the raw code so a locale introduced by a future automated data update still renders. Chinese variants are named by region rather than script to avoid mislabeling a track.
- `App.tsx` — `matchesLocales` matcher; both sections spliced into the facet funnel between basic and maturity; blank locale codes (present on a few titles) dropped from options and counts; the twice-duplicated filter literal extracted into `DEFAULT_FILTER`, since four object literals would have needed to stay in sync
- `FilterControls.tsx` / `App.css` — sections modeled on the Genres section, plus the hint line
- `tests/language-filters.spec.ts` — 13 new Playwright specs
- `README.md` — feature bullet

Maturity-rating facet counts now funnel from the subtitle stage rather than the basic stage, preserving the existing invariant that each section's counts sum to the set entering it.

## Testing

- `npm run lint` clean (the CI gate), `npm run build` clean
- 13 new Playwright specs pass, covering OR across includes bounded by the union, exclude beating include, the third click clearing an option, facet counts matching what the filter returns and funneling correctly, the two sections narrowing each other, composition with search, the header inc/exc badge, and option ordering. One asserts no raw locale code reaches a label, so a newly added locale surfaces as a failing test rather than a `ja-JP` chip in the UI.
- Verified against the raw catalog: German audio 215, German ∪ French 251, excluding English subs 180 — matching an independent offline count of `anime.json`.

## Notes

Two pre-existing issues found while working, both unrelated and left untouched:

- `tests/example.spec.ts` fails on `main`: it asserts the Vite scaffold title `/Vite \+ React/`, but `index.html` says "Crunchyroll Advanced Search".
- `npx tsc --noEmit` reports 5 errors (`.css` module declarations, `import.meta.env`) identically before and after this change — there is no `vite-env.d.ts`. The build is unaffected, as `npm run build` is bare `vite build` with no typecheck step.

Language chips were deliberately not added to the anime cards — up to 24 per card would overwhelm the grid — and there is no "no subtitles" sentinel option for the 176 titles with empty `subtitle_locales`, unlike `UNRATED_MATURITY`; exclusion already treats those titles correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_017J6Re76XfkQbkQz88cJ7dA)_